### PR TITLE
chore(build): macOS 构建架构由 x64 改为 universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win --publish=never",
-    "build:mac": "npm run build && electron-builder --mac --publish=never",
+    "build:mac": "npm run build && electron-builder --mac dmg --universal --publish=never",
     "build:linux": "npm run build && electron-builder --linux --publish=never"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * macOS 应用程序现已支持通用二进制文件，可在 Intel 和 Apple Silicon Mac 上运行。
  * macOS 应用程序现以 DMG 格式分发。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->