### PR TITLE
Add stage preview refresh button for zoom display recovery

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -290,6 +290,7 @@ export const en: LocaleShape = {
     completed: 'Preview complete',
     stopped: 'Preview stopped',
     replay: 'Replay from beginning',
+    refreshPreview: 'Refresh preview',
     resume: 'Resume preview',
     pause: 'Pause preview',
     stop: 'Stop preview',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -286,6 +286,7 @@ export const ja: typeof en = {
     completed: 'プレビュー完了',
     stopped: 'プレビュー停止',
     replay: '最初から再生',
+    refreshPreview: 'プレビューを更新',
     resume: '再開',
     pause: '一時停止',
     stop: '停止',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -274,6 +274,7 @@ export const zhCN = {
     completed: '预览完成',
     stopped: '预览已停止',
     replay: '从头重播',
+    refreshPreview: '刷新预览',
     resume: '继续预览',
     pause: '暂停预览',
     stop: '停止预览',

--- a/src/i18n/locales/zh-HK.ts
+++ b/src/i18n/locales/zh-HK.ts
@@ -277,6 +277,7 @@ export const zhHK: LocaleShape = {
     completed: '預覽完成',
     stopped: '預覽已停止',
     replay: '從頭重播',
+    refreshPreview: '重新整理預覽',
     resume: '繼續預覽',
     pause: '暫停預覽',
     stop: '停止預覽',

--- a/src/windows/editor/EditorPreview.tsx
+++ b/src/windows/editor/EditorPreview.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { Application } from 'pixi.js'
-import { LoaderCircle, Pause, Play, RotateCcw, Square } from 'lucide-react'
+import { LoaderCircle, Pause, Play, RefreshCw, RotateCcw, Square } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { cn } from '@/lib/style'
 import { describeError as describeLogError, logger } from '@/lib/logger'
@@ -77,6 +77,7 @@ export function EditorPreview({
   const playbackQueueRef = useRef<Promise<void>>(Promise.resolve())
   const engineLifecycleRef = useRef<Promise<void>>(Promise.resolve())
   const [engine, setEngine] = useState<PreviewEngine | null>(null)
+  const [engineEpoch, setEngineEpoch] = useState<number>(0)
   const [status, setStatus] = useState<PreviewStatus>('idle')
   const [message, setMessage] = useState<string>(() => t('editor.waitingPreview'))
 
@@ -212,7 +213,7 @@ export function EditorPreview({
     return (): void => {
       disposeEngine()
     }
-  }, [input, onActiveSnippetIdsChange, t])
+  }, [engineEpoch, input, onActiveSnippetIdsChange, t])
 
   useEffect((): (() => void) | undefined => {
     if (!engine) return undefined
@@ -358,6 +359,15 @@ export function EditorPreview({
     onPreviewFromBeginning()
   }
 
+  function refreshPreview(): void {
+    if (status === 'loading') return
+    initialLoadRef.current = true
+    setEngine(null)
+    setStatus('loading')
+    setMessage(t('editor.initializingPreview'))
+    setEngineEpoch((current: number): number => current + 1)
+  }
+
   function togglePause(): void {
     const dispatcher: StoryDispatcher | undefined = sessionRef.current?.dispatcher
     if (!dispatcher) return
@@ -490,6 +500,18 @@ export function EditorPreview({
             onClick={stop}
           >
             <Square className="size-3.5 fill-current" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={compact ? 'size-9' : 'size-8'}
+            aria-label={t('editor.refreshPreview')}
+            title={t('editor.refreshPreview')}
+            disabled={status === 'loading'}
+            onClick={refreshPreview}
+          >
+            <RefreshCw className={cn('size-3.5', status === 'loading' && 'animate-spin')} />
           </Button>
         </div>
         <div className={cn('mx-3 h-px flex-1', compact ? 'bg-white/15' : 'bg-border')} />


### PR DESCRIPTION
## Summary
- Adds a **Refresh preview** control on the editor stage preview toolbar so users can remount the Pixi engine after OS/window zoom causes incorrect stage sizing (workaround for #106).
- Refresh tears down and reinitializes the preview engine with the current stage size / DPR / settings, then restarts playback with the current story target.
- Adds `editor.refreshPreview` i18n strings for `en`, `ja`, `zh-CN`, and `zh-HK`.

## Notes
- This is an intentional manual workaround; it does not reintroduce the reverted layout-math approach from PR #139.
- Existing replay / pause / stop behavior is unchanged.

## Test plan
- [x] `pnpm typecheck`
- [ ] Open editor preview, change OS/window zoom until the stage looks wrong, click **Refresh preview**, confirm canvas remounts and layout recovers
- [ ] Confirm replay / pause / stop still work after a refresh
- [ ] Confirm the refresh button is disabled/spins while loading and does not double-init

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 编辑器预览区域新增“刷新预览”按钮，可手动重新加载预览内容。
  * 刷新过程中按钮将暂时禁用，并显示加载动画。
  * 新增英文、日文、简体中文及繁体中文界面文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->