### PR TITLE
feat(android): opt-in fullscreen mode for system bar occlusion

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -85,6 +85,9 @@ pub struct InteractionSettings {
     pub touch_mode: bool,
     #[serde(default)]
     pub touch_mode_prompt_seen: bool,
+    /// Android-only: force immersive system bars off to avoid occlusion.
+    #[serde(default)]
+    pub fullscreen_mode: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -311,6 +314,7 @@ mod tests {
         assert_eq!(settings.language, "system");
         assert_eq!(settings.onboarding.main_tour_version, 0);
         assert_eq!(settings.onboarding.editor_tour_version, 0);
+        assert!(!settings.interaction.fullscreen_mode);
     }
 
     #[test]

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -201,7 +201,11 @@ export const en: LocaleShape = {
     touchMode: 'Touch mode',
     touchModeDescription:
       'Keep list actions visible instead of relying on mouse hover, making them easier to use by touch.',
-    touchModeAria: 'Toggle touch mode'
+    touchModeAria: 'Toggle touch mode',
+    fullscreenMode: 'Fullscreen mode',
+    fullscreenModeDescription:
+      'Force Android immersive fullscreen and hide the status and navigation bars. Use this if the system navigation bar covers the bottom of the app.',
+    fullscreenModeAria: 'Toggle fullscreen mode'
   },
   about: {
     specialThanks: 'Special Thanks',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -197,7 +197,11 @@ export const ja: typeof en = {
     touchMode: 'タッチモード',
     touchModeDescription:
       'マウスホバーを使わず、一覧の操作ボタンを常に表示して指で操作しやすくします。',
-    touchModeAria: 'タッチモードを切り替え'
+    touchModeAria: 'タッチモードを切り替え',
+    fullscreenMode: 'フルスクリーンモード',
+    fullscreenModeDescription:
+      'Androidの没入型フルスクリーンを強制し、ステータスバーとナビゲーションバーを隠します。システムナビが画面下部を覆う場合に使用してください。',
+    fullscreenModeAria: 'フルスクリーンモードを切り替え'
   },
   about: {
     specialThanks: 'スペシャルサンクス',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -187,7 +187,11 @@ export const zhCN = {
     interactionDescription: '针对触控设备优化按钮与操作入口的显示方式。',
     touchMode: '触控模式',
     touchModeDescription: '开启后不依赖鼠标悬停，列表操作按钮会始终显示，更适合手指操作。',
-    touchModeAria: '切换触控模式'
+    touchModeAria: '切换触控模式',
+    fullscreenMode: '全屏模式',
+    fullscreenModeDescription:
+      '强制开启 Android 沉浸式全屏，隐藏状态栏与导航栏。若系统导航栏遮挡页面底部，可打开此选项。',
+    fullscreenModeAria: '切换全屏模式'
   },
   about: {
     specialThanks: '特别鸣谢',

--- a/src/i18n/locales/zh-HK.ts
+++ b/src/i18n/locales/zh-HK.ts
@@ -191,7 +191,11 @@ export const zhHK: LocaleShape = {
     interactionDescription: '針對觸控裝置最佳化按鈕與操作入口的顯示方式。',
     touchMode: '觸控模式',
     touchModeDescription: '開啟後不依賴滑鼠懸停，列表操作按鈕會保持顯示，更適合手指操作。',
-    touchModeAria: '切換觸控模式'
+    touchModeAria: '切換觸控模式',
+    fullscreenMode: '全螢幕模式',
+    fullscreenModeDescription:
+      '強制開啟 Android 沉浸式全螢幕，隱藏狀態列與導覽列。若系統導覽列遮擋頁面底部，可開啟此選項。',
+    fullscreenModeAria: '切換全螢幕模式'
   },
   about: {
     specialThanks: '特別鳴謝',

--- a/src/lib/orientation.ts
+++ b/src/lib/orientation.ts
@@ -72,21 +72,26 @@ export function unlockOrientation(): void {
 }
 
 export function enterImmersiveMode(): boolean {
+  return setImmersiveMode(true)
+}
+
+export function exitImmersiveMode(): void {
+  setImmersiveMode(false)
+}
+
+export function setImmersiveMode(enabled: boolean): boolean {
   const nativeBridge: NativeOrientationBridge | undefined = getNativeOrientationBridge()
   if (!nativeBridge?.setImmersive) return false
 
   try {
-    nativeBridge.setImmersive(true)
+    nativeBridge.setImmersive(enabled)
     return true
   } catch {
     return false
   }
 }
 
-export function exitImmersiveMode(): void {
-  try {
-    getNativeOrientationBridge()?.setImmersive?.(false)
-  } catch {
-    // The activity may already be closing.
-  }
+/** Apply Android immersive fullscreen from the settings preference. */
+export function applyFullscreenModePreference(enabled: boolean): boolean {
+  return setImmersiveMode(enabled)
 }

--- a/src/lib/touchMode.ts
+++ b/src/lib/touchMode.ts
@@ -1,11 +1,14 @@
 export type InteractionSettings = {
   touchMode: boolean
   touchModePromptSeen: boolean
+  /** Android-only: force immersive system bars off to avoid occlusion. */
+  fullscreenMode: boolean
 }
 
 export const DEFAULT_INTERACTION: InteractionSettings = {
   touchMode: false,
-  touchModePromptSeen: false
+  touchModePromptSeen: false,
+  fullscreenMode: false
 }
 
 export function detectPreferTouchMode(): boolean {
@@ -36,6 +39,10 @@ export function normalizeInteractionSettings(
       : detectDefaultWhenMissing
         ? detectPreferTouchMode()
         : DEFAULT_INTERACTION.touchMode,
-    touchModePromptSeen: Boolean(value?.touchModePromptSeen)
+    touchModePromptSeen: Boolean(value?.touchModePromptSeen),
+    fullscreenMode:
+      typeof value?.fullscreenMode === 'boolean'
+        ? value.fullscreenMode
+        : DEFAULT_INTERACTION.fullscreenMode
   }
 }

--- a/src/settings/useSettingsState.ts
+++ b/src/settings/useSettingsState.ts
@@ -40,6 +40,7 @@ export type SettingsHook = {
   setOnboarding: (value: OnboardingSettings) => void
   setInteraction: (value: InteractionSettings) => void
   setTouchMode: (value: boolean) => void
+  setFullscreenMode: (value: boolean) => void
   setWorkspaceDir: (dir: string) => void
 }
 
@@ -241,6 +242,11 @@ export function useSettingsState(): SettingsHook {
       setInteractionState((prev) => ({
         ...prev,
         touchMode: value
+      })),
+    setFullscreenMode: (value) =>
+      setInteractionState((prev) => ({
+        ...prev,
+        fullscreenMode: value
       })),
     setWorkspaceDir: (dir: string): void => {
       // Persist immediately so backend project commands never race with the

--- a/src/windows/editor/EditorRoot.tsx
+++ b/src/windows/editor/EditorRoot.tsx
@@ -7,6 +7,7 @@ import { describeError, logger } from '@/lib/logger'
 import { getSettings, saveSettings } from '@/settings/api'
 import type { AppSettings, SystemTheme } from '@/settings/types'
 import { useSystemTheme } from '@/settings/useSystemTheme'
+import { normalizeInteractionSettings } from '@/lib/touchMode'
 import App from './App'
 import { EDITOR_TOUR_VERSION, normalizeOnboardingSettings } from '@/onboarding/types'
 import { applyAppLanguage } from '@/i18n'
@@ -73,10 +74,9 @@ export function EditorRoot({
             ...normalizeOnboardingSettings(stored.onboarding),
             editorTourVersion: EDITOR_TOUR_VERSION
           },
-          interaction: {
-            touchMode: stored.interaction?.touchMode ?? false,
-            touchModePromptSeen: stored.interaction?.touchModePromptSeen ?? false
-          }
+          interaction: normalizeInteractionSettings(stored.interaction, {
+            detectDefaultWhenMissing: false
+          })
         }
         setSettings(nextSettings)
         await saveSettings(nextSettings)

--- a/src/windows/main/App.tsx
+++ b/src/windows/main/App.tsx
@@ -12,7 +12,8 @@ import { Agentation } from 'agentation'
 import { ProjectImportCoordinator } from '@/windows/main/components/ProjectImportCoordinator'
 import { ProjectsMetadataProvider } from '@/windows/main/providers/ProjectsMetadataProvider'
 import { AppNavigator } from '@/windows/shell/AppNavigator'
-import { prefersInAppNavigation } from '@/lib/platform'
+import { getRuntimePlatform, prefersInAppNavigation } from '@/lib/platform'
+import { applyFullscreenModePreference } from '@/lib/orientation'
 import { useViewportMode, type ViewportMode } from '@/hooks/useViewportMode'
 import { cn } from '@/lib/style'
 import { useTranslation } from 'react-i18next'
@@ -39,7 +40,7 @@ export default function App(): React.JSX.Element {
 
 function AppContent(): React.JSX.Element {
   const { t } = useTranslation()
-  const { appearance, loaded, workspaceDir, setWorkspaceDir } = useSettings()
+  const { appearance, loaded, workspaceDir, setWorkspaceDir, interaction } = useSettings()
   const activeTheme = appearance.activeTheme
   const location = useLocation()
   const viewportMode: ViewportMode = useViewportMode()
@@ -56,6 +57,12 @@ function AppContent(): React.JSX.Element {
     root.classList.toggle('dark', activeTheme === 'dark')
     root.style.colorScheme = activeTheme
   }, [activeTheme])
+
+  useEffect((): void => {
+    if (!loaded) return
+    if (getRuntimePlatform() !== 'android') return
+    applyFullscreenModePreference(interaction.fullscreenMode)
+  }, [interaction.fullscreenMode, loaded])
 
   if (!loaded) {
     return <></>

--- a/src/windows/main/pages/HomePage.tsx
+++ b/src/windows/main/pages/HomePage.tsx
@@ -49,12 +49,13 @@ export default function HomePage(): JSX.Element {
   const finishTouchPrompt = useCallback(
     (enabled: boolean): void => {
       setInteraction({
+        ...interaction,
         touchMode: enabled,
         touchModePromptSeen: true
       })
       setTouchPromptOpen(false)
     },
-    [setInteraction]
+    [interaction, setInteraction]
   )
 
   const latest: ProjectMetadata | null =

--- a/src/windows/main/pages/SettingsPage.tsx
+++ b/src/windows/main/pages/SettingsPage.tsx
@@ -56,6 +56,7 @@ export default function SettingsPage(): JSX.Element {
     setShortcuts,
     setOnboarding,
     setTouchMode,
+    setFullscreenMode,
     setWorkspaceDir
   } = useSettings()
   const navigate = useNavigate()
@@ -311,6 +312,18 @@ export default function SettingsPage(): JSX.Element {
             onCheckedChange={setTouchMode}
           />
         </SettingRow>
+        {androidRuntime ? (
+          <SettingRow
+            title={t('settings.fullscreenMode')}
+            description={t('settings.fullscreenModeDescription')}
+          >
+            <Switch
+              checked={interaction.fullscreenMode}
+              aria-label={t('settings.fullscreenModeAria')}
+              onCheckedChange={setFullscreenMode}
+            />
+          </SettingRow>
+        ) : null}
       </div>
 
       <div className="mt-8 mb-2 w-full max-w-2xl space-y-1">

--- a/src/windows/player/App.tsx
+++ b/src/windows/player/App.tsx
@@ -7,8 +7,8 @@ import { ArrowLeft, RotateCcw } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { prefersInAppNavigation } from '@/lib/platform'
 import {
+  applyFullscreenModePreference,
   enterImmersiveMode,
-  exitImmersiveMode,
   lockLandscapeOrientation,
   unlockOrientation
 } from '@/lib/orientation'
@@ -86,11 +86,16 @@ export default function App({
   const [reloadRequest, setReloadRequest] = useState<number>(0)
   const [shortcutOverride, setShortcutOverride] = useState<ShortcutSettings | null>(null)
   const [mobileControlsVisible, setMobileControlsVisible] = useState<boolean>(false)
+  const fullscreenModeRef = useRef<boolean>(false)
   const shortcuts: ShortcutSettings = useMemo(
     (): ShortcutSettings =>
       normalizeShortcutSettings(shortcutOverride ?? storyInput?.settings?.shortcuts),
     [shortcutOverride, storyInput?.settings?.shortcuts]
   )
+
+  const restoreImmersivePreference = useCallback((): void => {
+    applyFullscreenModePreference(fullscreenModeRef.current)
+  }, [])
 
   const clearControlsHideTimer = useCallback((): void => {
     if (controlsHideTimerRef.current === null) return
@@ -114,6 +119,7 @@ export default function App({
 
     void listen<AppSettings>('settings-changed', (event: TauriEvent<AppSettings>): void => {
       if (!disposed) setShortcutOverride(normalizeShortcutSettings(event.payload.shortcuts))
+      fullscreenModeRef.current = Boolean(event.payload.interaction?.fullscreenMode)
       applyAppLanguage(event.payload.language)
     }).then((dispose: () => void): void => {
       if (disposed) dispose()
@@ -141,7 +147,7 @@ export default function App({
       }
       if (cancelled) {
         await currentWindow.setFullscreen(false).catch((): void => undefined)
-        exitImmersiveMode()
+        restoreImmersivePreference()
         return
       }
 
@@ -152,7 +158,7 @@ export default function App({
       if (cancelled) {
         if (locked) unlockOrientation()
         await currentWindow.setFullscreen(false).catch((): void => undefined)
-        exitImmersiveMode()
+        restoreImmersivePreference()
         return
       }
       if (locked) logger.info('player.orientation_locked', { orientation: 'landscape' })
@@ -167,10 +173,10 @@ export default function App({
         .catch((error: unknown): void => {
           logger.warn('player.mobile_fullscreen_exit_failed', { error: describeError(error) })
         })
-        .finally((): void => exitImmersiveMode())
+        .finally((): void => restoreImmersivePreference())
       logger.info('player.orientation_unlocked')
     }
-  }, [clearControlsHideTimer, inAppNavigation])
+  }, [clearControlsHideTimer, inAppNavigation, restoreImmersivePreference])
 
   useEffect((): (() => void) => {
     const currentWindow: TauriWindow = getCurrentWindow()
@@ -244,6 +250,7 @@ export default function App({
     loadPlayerStoryInput(projectName)
       .then((input: PlayerStoryInput): void => {
         if (cancelled) return
+        fullscreenModeRef.current = Boolean(input.settings?.interaction?.fullscreenMode)
         setStoryInput(input)
         setLoadState({ status: 'ready' })
         logger.info('player.project_load_completed', {


### PR DESCRIPTION
## Summary
- Adds an Android-only **Fullscreen mode** setting (default **off**) under Interaction.
- When enabled, forces native immersive mode via the existing `MssOrientation.setImmersive` bridge so status/navigation bars stay hidden and content is not covered by the system nav bar (#105).
- Player still forces immersive while open; on exit it **restores** the setting instead of always leaving immersive mode.

## Why
Some Android devices (e.g. iQOO Neo 11) still show system navigation bars over the app shell despite edge-to-edge / safe-area handling. An opt-in force-fullscreen path is a safer workaround than changing default behavior for all devices.

## Changes
- `interaction.fullscreenMode` in TS + Rust settings (legacy configs default to `false`)
- Main shell applies preference on Android after settings load
- Settings UI switch (Android only) + i18n (`en` / `ja` / `zh-CN` / `zh-HK`)
- Player cleanup restores preference
- Editor tour save uses `normalizeInteractionSettings` so the new field is preserved

## Test plan
- [x] `pnpm typecheck`
- [x] `cd src-tauri && cargo test settings`
- [x] `cd src-tauri && cargo check`
- [ ] Android: Settings → enable Fullscreen mode → system bars hide
- [ ] Android: disable → bars return
- [ ] Setting off: open player → immersive; leave player → bars return
- [ ] Setting on: open/leave player → remains immersive
- [ ] Confirm bottom nav / page content is no longer permanently covered when mode is on (device-dependent; reported on iQOO Neo 11)

Fixes #105