### PR TITLE
Disable Save button when editor story is clean

### DIFF
--- a/src/windows/editor/App.tsx
+++ b/src/windows/editor/App.tsx
@@ -243,12 +243,15 @@ export default function App({
   const flushEditorWritesRef = useRef<() => Promise<boolean>>(
     (): Promise<boolean> => Promise.resolve(true)
   )
+  const canManualSaveRef = useRef<boolean>(false)
 
   const story: EditorStory = history.present
   storyRef.current = story
   loadedProjectRef.current = loadedProject
   const isDirty: boolean = !storiesEqual(history.present, history.saved)
   const editorSaving: boolean = savingStory || savingAssets || projectMutationInProgress
+  const canManualSave: boolean = !editorSaving && (isDirty || storySaveStatus === 'error')
+  canManualSaveRef.current = canManualSave
   const saveButtonTitle: string = editorSaving
     ? t('editor.saving')
     : storySaveStatus === 'error'
@@ -299,6 +302,7 @@ export default function App({
     function saveOnShortcut(event: KeyboardEvent): void {
       if (!matchesShortcut(event, saveShortcut)) return
       event.preventDefault()
+      if (!canManualSaveRef.current) return
       void flushEditorWritesRef.current()
     }
 
@@ -1314,6 +1318,7 @@ export default function App({
             className={cn('size-9', storySaveStatus === 'error' && 'text-destructive')}
             aria-label={saveButtonTitle}
             title={saveButtonTitle}
+            disabled={!canManualSave}
             onClick={(): void => {
               void flushEditorWrites()
             }}


### PR DESCRIPTION
## Summary
- Disable the editor toolbar Save button when the present story matches the last saved snapshot, so a clean project is visually non-interactive.
- Keep Save enabled after a failed save (retry) and while there are unsaved edits; disable it during in-flight save/asset/mutation work.
- Match keyboard save shortcut behavior to the same enablement gate.

Fixes #110

## Test plan
- [ ] Open a project with no edits → Save button disabled and title/tooltip shows “Saved”
- [ ] Edit a snippet → Save becomes enabled (“Save now”)
- [ ] Click Save or wait for autosave → Save returns to disabled once clean
- [ ] Confirm dirty amber indicator still tracks unsaved edits
- [ ] Confirm undo/redo still work independently
- [ ] (Optional) If a save fails, button stays clickable with retry styling

## Notes
- `pnpm typecheck` passed after the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化编辑器保存状态管理：正在保存、内容未修改或处于错误状态时，将正确限制手动保存操作。
  - 保存按钮会根据当前状态自动启用或禁用，避免重复保存或无效操作。
  - 键盘快捷键与界面按钮的保存行为保持一致，提升编辑体验和操作可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->